### PR TITLE
Fix comment typo

### DIFF
--- a/src/components/MessageBox.tsx
+++ b/src/components/MessageBox.tsx
@@ -57,7 +57,7 @@ const MessageBox = ({
       const closeThinkTag = processedMessage.match(/<\/think>/g)?.length || 0;
 
       if (openThinkTag > closeThinkTag) {
-        processedMessage += '</think> <a> </a>'; // The extra <a> </a> is to prevent the the think component from looking bad
+        processedMessage += '</think> <a> </a>'; // The extra <a> </a> is to prevent the think component from looking bad
       }
     }
 


### PR DESCRIPTION
## Summary
- fix typo in MessageBox comment

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: SIGINT / environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_683fa47934ec832e85ceef00d5abdbaa