### PR TITLE
Fix rewrite first message case

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -514,7 +514,9 @@ const ChatWindow = ({ id }: { id?: string }) => {
   const rewrite = (messageId: string) => {
     const index = messages.findIndex((msg) => msg.messageId === messageId);
 
-    if (index === -1) return;
+    // The first message cannot be rewritten because there is no prior user
+    // input, and we also exit if the message isn't found.
+    if (index <= 0) return;
 
     const message = messages[index - 1];
 


### PR DESCRIPTION
## Summary
- avoid rewriting the first chat message in ChatWindow
- document why the first message can't be rewritten

## Testing
- `npm run format:write`

------
https://chatgpt.com/codex/tasks/task_e_683fa4781718832eb12ea63eca13f676