### PR TITLE
Fix spelling of receivedMessage

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -59,7 +59,7 @@ const handleEmitterEvents = async (
   aiMessageId: string,
   chatId: string,
 ) => {
-  let recievedMessage = '';
+  let receivedMessage = '';
   let sources: any[] = [];
 
   stream.on('data', (data) => {
@@ -75,7 +75,7 @@ const handleEmitterEvents = async (
         ),
       );
 
-      recievedMessage += parsedData.data;
+      receivedMessage += parsedData.data;
     } else if (parsedData.type === 'sources') {
       writer.write(
         encoder.encode(
@@ -103,7 +103,7 @@ const handleEmitterEvents = async (
 
     db.insert(messagesSchema)
       .values({
-        content: recievedMessage,
+        content: receivedMessage,
         chatId: chatId,
         messageId: aiMessageId,
         role: 'assistant',

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -338,7 +338,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
     setMessageAppeared(false);
 
     let sources: Document[] | undefined = undefined;
-    let recievedMessage = '';
+    let receivedMessage = '';
     let added = false;
 
     messageId = messageId ?? crypto.randomBytes(7).toString('hex');
@@ -406,7 +406,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
           }),
         );
 
-        recievedMessage += data.data;
+        receivedMessage += data.data;
         setMessageAppeared(true);
       }
 
@@ -414,7 +414,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
         setChatHistory((prevHistory) => [
           ...prevHistory,
           ['human', message],
-          ['assistant', recievedMessage],
+          ['assistant', receivedMessage],
         ]);
 
         setLoading(false);


### PR DESCRIPTION
## Summary
- rename `recievedMessage` to `receivedMessage` in ChatWindow and chat API

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_683fa4770b44832ea652570abb8c6176