### PR TITLE
Add Simplified Chinese UI option

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import Sidebar from '@/components/Sidebar';
 import { Toaster } from 'sonner';
 import ThemeProvider from '@/components/theme/Provider';
+import LanguageProvider from '@/components/language/Provider';
 
 const montserrat = Montserrat({
   weight: ['300', '400', '500', '700'],
@@ -27,18 +28,20 @@ export default function RootLayout({
   return (
     <html className="h-full" lang="en" suppressHydrationWarning>
       <body className={cn('h-full', montserrat.className)}>
-        <ThemeProvider>
-          <Sidebar>{children}</Sidebar>
-          <Toaster
-            toastOptions={{
-              unstyled: true,
-              classNames: {
-                toast:
-                  'bg-light-primary dark:bg-dark-secondary dark:text-white/70 text-black-70 rounded-lg p-4 flex flex-row items-center space-x-2',
-              },
-            }}
-          />
-        </ThemeProvider>
+        <LanguageProvider>
+          <ThemeProvider>
+            <Sidebar>{children}</Sidebar>
+            <Toaster
+              toastOptions={{
+                unstyled: true,
+                classNames: {
+                  toast:
+                    'bg-light-primary dark:bg-dark-secondary dark:text-white/70 text-black-70 rounded-lg p-4 flex flex-row items-center space-x-2',
+                },
+              }}
+            />
+          </ThemeProvider>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -5,6 +5,7 @@ import { cn, formatTimeDifference } from '@/lib/utils';
 import { BookOpenText, ClockIcon, Delete, ScanEye } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { useLanguage } from '@/components/language/Provider';
 
 export interface Chat {
   id: string;
@@ -16,6 +17,7 @@ export interface Chat {
 const Page = () => {
   const [chats, setChats] = useState<Chat[]>([]);
   const [loading, setLoading] = useState(true);
+  const { t } = useLanguage();
 
   useEffect(() => {
     const fetchChats = async () => {
@@ -61,14 +63,14 @@ const Page = () => {
       <div className="flex flex-col pt-4">
         <div className="flex items-center">
           <BookOpenText />
-          <h1 className="text-3xl font-medium p-2">Library</h1>
+          <h1 className="text-3xl font-medium p-2">{t('libraryTitle')}</h1>
         </div>
         <hr className="border-t border-[#2B2C2C] my-4 w-full" />
       </div>
       {chats.length === 0 && (
         <div className="flex flex-row items-center justify-center min-h-screen">
           <p className="text-black/70 dark:text-white/70 text-sm">
-            No chats found.
+            {t('noChatsFound')}
           </p>
         </div>
       )}
@@ -94,7 +96,7 @@ const Page = () => {
                 <div className="flex flex-row items-center space-x-1 lg:space-x-1.5 text-black/70 dark:text-white/70">
                   <ClockIcon size={15} />
                   <p className="text-xs">
-                    {formatTimeDifference(new Date(), chat.createdAt)} Ago
+                    {formatTimeDifference(new Date(), chat.createdAt)} {t('ago')}
                   </p>
                 </div>
                 <DeleteChat

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Switch } from '@headlessui/react';
 import ThemeSwitcher from '@/components/theme/Switcher';
+import LanguageSwitcher from '@/components/language/Switcher';
+import { useLanguage } from '@/components/language/Provider';
 import { ImagesIcon, VideoIcon } from 'lucide-react';
 import Link from 'next/link';
 import { PROVIDER_METADATA } from '@/lib/providers';
@@ -132,6 +134,7 @@ const Page = () => {
   const [embeddingModels, setEmbeddingModels] = useState<Record<string, any>>(
     {},
   );
+  const { t } = useLanguage();
   const [selectedChatModelProvider, setSelectedChatModelProvider] = useState<
     string | null
   >(null);
@@ -419,9 +422,15 @@ const Page = () => {
             <SettingsSection title="Appearance">
               <div className="flex flex-col space-y-1">
                 <p className="text-black/70 dark:text-white/70 text-sm">
-                  Theme
+                  {t('theme')}
                 </p>
                 <ThemeSwitcher />
+              </div>
+              <div className="flex flex-col space-y-1">
+                <p className="text-black/70 dark:text-white/70 text-sm">
+                  {t('language')}
+                </p>
+                <LanguageSwitcher />
               </div>
             </SettingsSection>
 
@@ -437,11 +446,10 @@ const Page = () => {
                     </div>
                     <div>
                       <p className="text-sm text-black/90 dark:text-white/90 font-medium">
-                        Automatic Image Search
+                        {t('automaticImageSearch')}
                       </p>
                       <p className="text-xs text-black/60 dark:text-white/60 mt-0.5">
-                        Automatically search for relevant images in chat
-                        responses
+                        {t('automaticallySearchImages')}
                       </p>
                     </div>
                   </div>

--- a/src/components/EmptyChat.tsx
+++ b/src/components/EmptyChat.tsx
@@ -1,6 +1,7 @@
 import { Settings } from 'lucide-react';
 import EmptyChatMessageInput from './EmptyChatMessageInput';
 import { useState } from 'react';
+import { useLanguage } from './language/Provider';
 import { File } from './ChatWindow';
 import Link from 'next/link';
 
@@ -24,8 +25,9 @@ const EmptyChat = ({
   setFileIds: (fileIds: string[]) => void;
   files: File[];
   setFiles: (files: File[]) => void;
-}) => {
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  }) => {
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+    const { t } = useLanguage();
 
   return (
     <div className="relative">
@@ -36,7 +38,7 @@ const EmptyChat = ({
       </div>
       <div className="flex flex-col items-center justify-center min-h-screen max-w-screen-sm mx-auto p-2 space-y-8">
         <h2 className="text-black/70 dark:text-white/70 text-3xl font-medium -mt-8">
-          Research begins here.
+          {t('researchBeginsHere')}
         </h2>
         <EmptyChatMessageInput
           sendMessage={sendMessage}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { Message } from './ChatWindow';
 import { useEffect, useState } from 'react';
 import { formatTimeDifference } from '@/lib/utils';
 import DeleteChat from './DeleteChat';
+import { useLanguage } from './language/Provider';
 
 const Navbar = ({
   chatId,
@@ -13,6 +14,7 @@ const Navbar = ({
 }) => {
   const [title, setTitle] = useState<string>('');
   const [timeAgo, setTimeAgo] = useState<string>('');
+  const { t } = useLanguage();
 
   useEffect(() => {
     if (messages.length > 0) {
@@ -54,7 +56,7 @@ const Navbar = ({
       </a>
       <div className="hidden lg:flex flex-row items-center justify-center space-x-2">
         <Clock size={17} />
-        <p className="text-xs">{timeAgo} ago</p>
+        <p className="text-xs">{timeAgo} {t('ago')}</p>
       </div>
       <p className="hidden lg:flex">{title}</p>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useSelectedLayoutSegments } from 'next/navigation';
 import React, { useState, type ReactNode } from 'react';
 import Layout from './Layout';
+import { useLanguage } from './language/Provider';
 
 const VerticalIconContainer = ({ children }: { children: ReactNode }) => {
   return (
@@ -15,25 +16,26 @@ const VerticalIconContainer = ({ children }: { children: ReactNode }) => {
 
 const Sidebar = ({ children }: { children: React.ReactNode }) => {
   const segments = useSelectedLayoutSegments();
+  const { t } = useLanguage();
 
   const navLinks = [
     {
       icon: Home,
       href: '/',
       active: segments.length === 0 || segments.includes('c'),
-      label: 'Home',
+      label: t('home'),
     },
     {
       icon: Search,
       href: '/discover',
       active: segments.includes('discover'),
-      label: 'Discover',
+      label: t('discover'),
     },
     {
       icon: BookOpenText,
       href: '/library',
       active: segments.includes('library'),
-      label: 'Library',
+      label: t('library'),
     },
   ];
 

--- a/src/components/language/Provider.tsx
+++ b/src/components/language/Provider.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { translations, type Language } from '@/lib/i18n';
+
+interface LanguageContextType {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+}
+
+const LanguageContext = createContext<LanguageContextType>({
+  language: 'en',
+  setLanguage: () => {},
+  t: (key: string) => translations.en[key] ?? key,
+});
+
+const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
+  const [language, setLanguage] = useState<Language>('en');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('language');
+    if (stored === 'zh' || stored === 'en') {
+      setLanguage(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('language', language);
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = language;
+    }
+  }, [language]);
+
+  const t = (key: string) => {
+    return translations[language][key] ?? translations.en[key] ?? key;
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);
+
+export default LanguageProvider;

--- a/src/components/language/Switcher.tsx
+++ b/src/components/language/Switcher.tsx
@@ -1,0 +1,20 @@
+'use client';
+import Select from '../ui/Select';
+import { useLanguage } from './Provider';
+
+const LanguageSwitcher = ({ className }: { className?: string }) => {
+  const { language, setLanguage } = useLanguage();
+  return (
+    <Select
+      className={className}
+      value={language}
+      onChange={(e) => setLanguage(e.target.value as any)}
+      options={[
+        { value: 'en', label: 'English' },
+        { value: 'zh', label: '简体中文' },
+      ]}
+    />
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,32 @@
+export type Language = 'en' | 'zh';
+
+export const translations: Record<Language, Record<string, string>> = {
+  en: {
+    home: 'Home',
+    discover: 'Discover',
+    library: 'Library',
+    settings: 'Settings',
+    researchBeginsHere: 'Research begins here.',
+    libraryTitle: 'Library',
+    noChatsFound: 'No chats found.',
+    theme: 'Theme',
+    language: 'Language',
+    automaticImageSearch: 'Automatic Image Search',
+    automaticallySearchImages: 'Automatically search for relevant images in chat responses',
+    ago: 'ago',
+  },
+  zh: {
+    home: '首页',
+    discover: '发现',
+    library: '知识库',
+    settings: '设置',
+    researchBeginsHere: '研究从这里开始。',
+    libraryTitle: '知识库',
+    noChatsFound: '未找到聊天记录。',
+    theme: '主题',
+    language: '语言',
+    automaticImageSearch: '自动图片搜索',
+    automaticallySearchImages: '自动在聊天回复中搜索相关图片',
+    ago: '前',
+  },
+};


### PR DESCRIPTION
## Summary
- add language provider and switcher
- wrap layout with language provider
- translate sidebar, empty chat text, library page, navbar and settings
- provide translations for Chinese/English

## Testing
- `npm install` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa69ad7b0832ebf48fbb05b73d744