### PR TITLE
Fix chatHistory name typo

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,6 @@
 import { Message } from '@/components/ChatWindow';
 
-export const getSuggestions = async (chatHisory: Message[]) => {
+export const getSuggestions = async (chatHistory: Message[]) => {
   const chatModel = localStorage.getItem('chatModel');
   const chatModelProvider = localStorage.getItem('chatModelProvider');
 
@@ -13,7 +13,7 @@ export const getSuggestions = async (chatHisory: Message[]) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      chatHistory: chatHisory,
+      chatHistory: chatHistory,
       chatModel: {
         provider: chatModelProvider,
         model: chatModel,


### PR DESCRIPTION
## Summary
- rename `chatHisory` parameter to `chatHistory`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683fa4767628832e932247998eaf67ba