### PR TITLE
Fix fileId path traversal

### DIFF
--- a/src/lib/search/metaSearchAgent.ts
+++ b/src/lib/search/metaSearchAgent.ts
@@ -24,6 +24,7 @@ import computeSimilarity from '../utils/computeSimilarity';
 import formatChatHistoryAsString from '../utils/formatHistory';
 import eventEmitter from 'events';
 import { StreamEvent } from '@langchain/core/tracers/log_stream';
+import { sanitizeFileId } from '../utils/files';
 
 export interface MetaSearchAgentType {
   searchAndAnswer: (
@@ -306,7 +307,8 @@ class MetaSearchAgent implements MetaSearchAgentType {
 
     const filesData = fileIds
       .map((file) => {
-        const filePath = path.join(process.cwd(), 'uploads', file);
+        const safeId = sanitizeFileId(file);
+        const filePath = path.join(process.cwd(), 'uploads', safeId);
 
         const contentPath = filePath + '-extracted.json';
         const embeddingsPath = filePath + '-embeddings.json';

--- a/src/lib/utils/files.ts
+++ b/src/lib/utils/files.ts
@@ -1,17 +1,30 @@
 import path from 'path';
 import fs from 'fs';
 
+/**
+ * Basic validation to ensure fileIds don't contain any path traversal
+ * characters. Throws an error if an invalid id is provided.
+ */
+export const sanitizeFileId = (fileId: string) => {
+  if (fileId.includes('..') || fileId.includes('/') || fileId.includes('\\')) {
+    throw new Error('Invalid file id');
+  }
+
+  return fileId;
+};
+
 export const getFileDetails = (fileId: string) => {
+  const safeId = sanitizeFileId(fileId);
   const fileLoc = path.join(
     process.cwd(),
     './uploads',
-    fileId + '-extracted.json',
+    safeId + '-extracted.json',
   );
 
   const parsedFile = JSON.parse(fs.readFileSync(fileLoc, 'utf8'));
 
   return {
     name: parsedFile.title,
-    fileId: fileId,
+    fileId: safeId,
   };
 };

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFileId } from '../src/lib/utils/files';
+
+describe('sanitizeFileId', () => {
+  it('throws an error for path traversal attempts', () => {
+    expect(() => sanitizeFileId('../etc/passwd')).toThrowError();
+    expect(() => sanitizeFileId('..\\etc\\passwd')).toThrowError();
+    expect(() => sanitizeFileId('foo/../../bar')).toThrowError();
+  });
+
+  it('allows simple ids', () => {
+    expect(sanitizeFileId('abc123')).toBe('abc123');
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize user-provided file IDs
- use the sanitizer when reading uploaded files
- add tests for the new helper

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683facae91a4832e98282c6184148575